### PR TITLE
Make maze walker start dir be away from end

### DIFF
--- a/game.js
+++ b/game.js
@@ -78,6 +78,7 @@ game.prototype.generate_npcs = function() {
         name: "wall walker",
         strategy: "always right",
         hit_box: "surrounding",
+        direction: this.maze.dir_from_tile_to_tile(this.maze.end, tile),
         speed: 150
       }));
     }

--- a/maze_gen.js
+++ b/maze_gen.js
@@ -361,4 +361,23 @@ mazeObj.prototype.get_relative_right = function(dir) {
   return "right";
 }
 
+mazeObj.prototype.dir_from_tile_to_tile = function(from, to) {
+  var x = to.x - from.x;
+  var y = to.y - from.y;
+  if (Math.abs(x) > Math.abs(y)) {
+    if (x > 0) {
+      return "right";
+    } else {
+      return "left";
+    }
+  } else {
+    if (y > 0) {
+      return "down";
+    } else {
+      return "up";
+    }
+  }
+  return "left";
+}
+
 exports.mazeObj = mazeObj;

--- a/npc.js
+++ b/npc.js
@@ -6,7 +6,7 @@ function npcObj(settings) {
   this.name = settings.name;
   this.hit_box = settings.hit_box;
   this.position = settings.position;
-  this.direction = 'left';
+  this.direction = settings.direction || 'left';
   this.last_position = settings.position;
   this.id = settings.id;
   this.speed = settings.speed;


### PR DESCRIPTION
This fixes the always turn right behavior to not get caught in small boxes
